### PR TITLE
Implement RowSet and RowRange.

### DIFF
--- a/plugin/ci/check.sh
+++ b/plugin/ci/check.sh
@@ -29,12 +29,14 @@ log "Testing if the cc sources are properly formatted."
 find \( -name \*.cc -o -name \*.h \) -print0 \
   | xargs -0 clang-format-10 --dry-run --Werror
 
-log "Compiling and installing the project"
-
 cd "$PROJECT_DIR"
-python3 setup.py install
 
 log "Installing the project"
+python3 setup.py develop
+
+log "Testing the project"
+LD_LIBRARY_PATH=/usr/local/lib/python3.8/dist-packages/torch/lib \
+	python3 -m unittest -v
 
 EMULATOR_LOG=$(mktemp)
 "$EMULATOR_PATH" -host 127.0.0.1 -port 0 >"$EMULATOR_LOG" &

--- a/plugin/pytorch_bigtable/__init__.py
+++ b/plugin/pytorch_bigtable/__init__.py
@@ -1,6 +1,1 @@
-import torch
-
-from pbt_C import get_data
-from pytorch_bigtable.example import get_data_py
-
-__all__ = ['get_data', 'get_data_py']
+from .bigtable_dataset import *

--- a/plugin/pytorch_bigtable/bigtable_dataset.py
+++ b/plugin/pytorch_bigtable/bigtable_dataset.py
@@ -1,8 +1,5 @@
-from _typeshed import Self
 import torch
-import math
 import pbt_C
-
 
 class BigtableClient:
     """CloudBigtableClient is the main entrypoint for

--- a/plugin/pytorch_bigtable/row_range.py
+++ b/plugin/pytorch_bigtable/row_range.py
@@ -1,0 +1,92 @@
+import pbt_C
+
+
+def infinite() -> pbt_C.RowRange:
+  """Create a infinite row range."""
+  return pbt_C.infinite_row_range()
+
+
+def starting_at(row_key: str) -> pbt_C.RowRange:
+  """Create a row range staring at given row (inclusive).
+
+  Args:
+    row_key (str): The starting row key of the range (inclusive).
+  Returns:
+    RowRange: The row range which starts at `row_key` (inclusive).
+  """
+  return pbt_C.starting_at_row_range(row_key)
+
+
+def ending_at(row_key: str) -> pbt_C.RowRange:
+  """Create a row range ending at given row (inclusive).
+
+  Args:
+    row_key (str): The ending row key of the range (inclusive).
+  Returns:
+    RowRange: The row range which ends at `row_key` (inclusive).
+  """
+  return pbt_C.ending_at_row_range(row_key)
+
+
+def empty() -> pbt_C.RowRange:
+  """Create an empty row range."""
+  return pbt_C.empty_row_range()
+
+
+def prefix(prefix_str: str) -> pbt_C.RowRange:
+  """Create a range of all rows starting with a given prefix.
+
+  Args:
+    prefix_str (str): The prefix with which all rows start
+  Returns:
+    RowRange: The row range of all rows starting with the given prefix.
+  """
+  return pbt_C.prefix_row_range(prefix_str)
+
+
+def right_open(start: str, end: str) -> pbt_C.RowRange:
+  """Create a row range exclusive at the start and inclusive at the end.
+
+  Args:
+    start (str): The start of the row range (inclusive).
+    end (str): The end of the row range (exclusive).
+  Returns:
+    RowRange: The row range between the `start` and `end`.
+  """
+  return pbt_C.right_open_row_range(start, end)
+
+
+def left_open(start: str, end: str) -> pbt_C.RowRange:
+  """Create a row range inclusive at the start and exclusive at the end.
+
+  Args:
+    start (str): The start of the row range (exclusive).
+    end (str): The end of the row range (inclusive).
+  Returns:
+    RowRange: The row range between the `start` and `end`.
+  """
+  return pbt_C.left_open_row_range(start, end)
+
+
+def open_range(start: str, end: str) -> pbt_C.RowRange:
+  """Create a row range exclusive at both the start and the end.
+
+  Args:
+    start (str): The start of the row range (exclusive).
+    end (str): The end of the row range (exclusive).
+  Returns:
+    RowRange: The row range between the `start` and `end`.
+  """
+  return pbt_C.open_row_range(start, end)
+
+
+def closed_range(start: str, end: str) -> pbt_C.RowRange:
+  """Create a row range inclusive at both the start and the end.
+
+  Args:
+    start (str): The start of the row range (inclusive).
+    end (str): The end of the row range (inclusive).
+  Returns:
+    RowRange: The row range between the `start` and `end`.
+  """
+  return pbt_C.closed_row_range(start, end)

--- a/plugin/pytorch_bigtable/row_set.py
+++ b/plugin/pytorch_bigtable/row_set.py
@@ -1,0 +1,43 @@
+import pbt_C
+from typing import Union
+
+
+def empty() -> pbt_C.RowSet:
+  """Create an empty row set."""
+  return pbt_C.RowSet()
+
+
+def from_rows_or_ranges(*args: Union[str, pbt_C.RowRange]) -> pbt_C.RowSet:
+  """ Create a set from a row range.
+
+  Args:
+    *args: A row range (RowRange) which will be
+        appended to an empty row set.
+  Returns:
+    RowSet: a set of rows containing the given row range.
+  """
+  row_set = pbt_C.RowSet()
+  for row_or_range in args:
+    row_set.append(row_or_range)
+
+  return row_set
+
+
+
+
+def intersect(row_set, row_range: pbt_C.RowRange) -> pbt_C.RowSet:
+  """ Modify a row set by intersecting its contents with a row range.
+
+  All rows intersecting with the given range will be removed from the set
+  and all row ranges will either be adjusted so that they do not cover
+  anything beyond the given range or removed entirely (if they have an
+  empty intersection with the given range).
+
+  Args:
+    row_set: A set (RowSet) which will be intersected.
+    row_range (RowRange): The range with which this row set will be
+        intersected.
+  Returns:
+    RowSet: an intersection of the given row set and row range.
+  """
+  return row_set.intersect(row_range)

--- a/plugin/pytorch_bigtable/tests/test_row_set.py
+++ b/plugin/pytorch_bigtable/tests/test_row_set.py
@@ -1,0 +1,107 @@
+from unittest import TestCase
+from pytorch_bigtable import row_set
+from pytorch_bigtable import row_range
+
+class RowRangeTest(TestCase):
+  def test_infinite(self):
+    self.assertEqual("", repr(row_range.infinite()))
+
+  def test_starting_at(self):
+    expected = 'start_key_closed: "row1"\n'
+    self.assertEqual(expected, repr(row_range.starting_at("row1")))
+
+  def test_ending_at(self):
+    expected = 'end_key_closed: "row1"\n'
+    self.assertEqual(expected, repr(row_range.ending_at("row1")))
+
+  def test_empty(self):
+    expected = (
+        'start_key_open: ""\n' +
+        'end_key_open: "\\000"\n')
+
+    self.assertEqual(expected, repr(row_range.empty()))
+
+  def test_prefix(self):
+    expected = (
+        'start_key_closed: "row1"\n'
+        'end_key_open: "row2"\n'
+        )
+    self.assertEqual(expected, repr(row_range.prefix("row1")))
+
+  def test_right_open(self):
+    expected = (
+        'start_key_closed: "row1"\n'
+        'end_key_open: "row2"\n'
+        )
+    self.assertEqual(expected, repr(row_range.right_open("row1", "row2")))
+
+  def test_left_open(self):
+    expected = (
+        'start_key_open: "row1"\n'
+        'end_key_closed: "row2"\n'
+        )
+    self.assertEqual(expected, repr(row_range.left_open("row1", "row2")))
+
+  def test_open(self):
+    expected = (
+        'start_key_open: "row1"\n'
+        'end_key_open: "row2"\n'
+        )
+    self.assertEqual(expected, repr(row_range.open_range("row1", "row2")))
+
+  def test_closed(self):
+    expected = (
+        'start_key_closed: "row1"\n' +
+        'end_key_closed: "row2"\n')
+    self.assertEqual(expected, repr(row_range.closed_range("row1", "row2")))
+
+class TestRowSet(TestCase):
+  def test_empty(self):
+    expected = ''
+    self.assertEqual(expected, repr(row_set.empty()))
+
+  def test_append_row(self):
+    r_set = row_set.empty()
+    r_set.append_row("row1")
+    expected = 'row_keys: "row1"\n'
+    self.assertEqual(expected, repr(r_set))
+
+  def test_append_row_range(self):
+    r_set = row_set.empty()
+    r_set.append_range(row_range.closed_range("row1", "row2"))
+    expected = (
+        'row_ranges {\n' +
+        '  start_key_closed: "row1"\n' +
+        '  end_key_closed: "row2"\n' +
+        '}\n')
+    self.assertEqual(expected, repr(r_set))
+
+  def test_from_rows_or_ranges(self):
+    expected = (
+        'row_keys: "row3"\n' +
+        'row_keys: "row6"\n' +
+        'row_ranges {\n' +
+        '  start_key_closed: "row1"\n' +
+        '  end_key_closed: "row2"\n' +
+        '}\n' +
+        'row_ranges {\n' +
+        '  start_key_open: "row4"\n' +
+        '  end_key_open: "row5"\n' +
+        '}\n')
+
+    r_set = row_set.from_rows_or_ranges(
+        row_range.closed_range("row1", "row2"),
+        "row3",
+        row_range.open_range("row4", "row5"),
+        "row6")
+    self.assertEqual(expected, repr(r_set))
+
+  def test_intersect(self):
+    r_set = row_set.from_rows_or_ranges(row_range.open_range("row1", "row5"))
+    r_set = r_set.intersect(row_range.closed_range("row3", "row7"))
+    expected = (
+        'row_ranges {\n' +
+        '  start_key_closed: "row3"\n' +
+        '  end_key_open: "row5"\n' +
+        '}\n')
+    self.assertEqual(expected, repr(r_set))


### PR DESCRIPTION
These classes are required to specify the rows which should be read into
pyTorch's tensors.

These classes are only a thin wrapper around the C++ classes. It needs
to be done that way because eventually, those C++ classes need to be
passed to the underlying library. An alternative approach would be to
create everything in python and create the C++ implementations when
needed but it would be more complicated for no benefit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/pytorch-cbt/13)
<!-- Reviewable:end -->
