### PR TITLE
feat: support other data types

### DIFF
--- a/plugin/csrc/bigtable_dataset.cc
+++ b/plugin/csrc/bigtable_dataset.cc
@@ -196,13 +196,13 @@ torch::Tensor getFilledTensor(size_t size, torch::Dtype const& cell_type,
       return default_value
                  ? torch::full(size, (*default_value).cast<float>(),
                                torch::TensorOptions().dtype(cell_type))
-                 : torch::full(size, NAN,
+                 : torch::full(size, 0.,
                                torch::TensorOptions().dtype(cell_type));
     case torch::kFloat64:
       return default_value
                  ? torch::full(size, (*default_value).cast<double>(),
                                torch::TensorOptions().dtype(cell_type))
-                 : torch::full(size, NAN,
+                 : torch::full(size, 0.,
                                torch::TensorOptions().dtype(cell_type));
     case torch::kI64:
       return default_value
@@ -223,7 +223,7 @@ class BigtableDatasetIterator {
                           py::list const& columns, py::object cell_type,
                           cbt::RowSet const& row_set,
                           cbt::Filter const& versions,
-                          std::optional<py::object> const& default_value,
+                          std::optional<py::object> default_value,
                           int /*num_workers*/, int /*worker_id*/)
       : column_map_(CreateColumnMap(columns)),
         default_value_(std::move(default_value)),

--- a/plugin/csrc/bigtable_dataset.cc
+++ b/plugin/csrc/bigtable_dataset.cc
@@ -223,8 +223,8 @@ class BigtableDatasetIterator {
                           py::list const& columns, py::object cell_type,
                           cbt::RowSet const& row_set,
                           cbt::Filter const& versions,
-                          std::optional<py::object> const& default_value, int /*num_workers*/,
-                          int /*worker_id*/)
+                          std::optional<py::object> const& default_value,
+                          int /*num_workers*/, int /*worker_id*/)
       : column_map_(CreateColumnMap(columns)),
         default_value_(std::move(default_value)),
         cell_type_(
@@ -325,12 +325,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   py::class_<BigtableDatasetIterator>(m, "Iterator")
       .def(py::init<std::shared_ptr<cbt::DataClient>, std::string,
                     std::optional<std::string>, py::list, py::list, py::object,
-                    cbt::RowSet const&, cbt::Filter, std::optional<py::object>, int, int>(),
+                    cbt::RowSet const&, cbt::Filter, std::optional<py::object>,
+                    int, int>(),
            "get BigTable ReadRows iterator", py::arg("client"),
            py::arg("table_id"), py::arg("app_profile_id") = py::none(),
            py::arg("sample_row_keys"), py::arg("columns"), py::arg("cell_type"),
-           py::arg("row_set"), py::arg("versions"), py::arg("default_value") = py::none(),
-           py::arg("num_workers"), py::arg("worker_id"))
+           py::arg("row_set"), py::arg("versions"),
+           py::arg("default_value") = py::none(), py::arg("num_workers"),
+           py::arg("worker_id"))
       .def("__iter__",
            [](BigtableDatasetIterator& it) -> BigtableDatasetIterator& {
              return it;

--- a/plugin/csrc/bigtable_dataset.cc
+++ b/plugin/csrc/bigtable_dataset.cc
@@ -47,6 +47,17 @@ void PutCellValueInTensor(torch::Tensor* tensor, int index,
   }
 }
 
+std::string GetTensorValueInBytes(torch::Tensor const& tensor, size_t i, size_t j) {
+  switch (tensor.scalar_type()) {
+    case torch::kFloat32: {
+      auto tensor_ptr = tensor.accessor<float, 2>();
+      return FloatToBytes(tensor_ptr[i][j]);
+    }
+    default:
+      throw std::runtime_error("type not implemented");
+  }
+}
+
 cbt::Filter CreateColumnsFilter(
     std::map<std::pair<std::string, std::string>, size_t> const& columns) {
   std::vector<cbt::Filter> filters;
@@ -108,8 +119,6 @@ void WriteTensor(std::shared_ptr<cbt::DataClient> const& data_client,
                  py::list const& row) {
   auto table = CreateTable(data_client, table_id, app_profile_id);
 
-  auto* tensor_ptr = static_cast<float*>(tensor.data_ptr());
-
   for (int i = 0; i < tensor.size(0); i++) {
     auto row_key = row[i].cast<std::string>();
 
@@ -118,8 +127,8 @@ void WriteTensor(std::shared_ptr<cbt::DataClient> const& data_client,
       auto [col_family, col_name] = ColumnNameToPair(col_name_full);
       google::cloud::Status status = table->Apply(cbt::SingleRowMutation(
           row_key, cbt::SetCell(std::move(col_family), std::move(col_name),
-                                FloatToBytes(*tensor_ptr))));
-      ++tensor_ptr;
+                                GetTensorValueInBytes(tensor, i, j))));
+//      ++tensor_ptr;
       if (!status.ok()) throw std::runtime_error(status.message());
     }
   }

--- a/plugin/pytorch_bigtable/bigtable_dataset.py
+++ b/plugin/pytorch_bigtable/bigtable_dataset.py
@@ -1,7 +1,7 @@
 """Module containing core functionality of pytorch bigtable dataset"""
 import torch
 import pbt_C
-from typing import List
+from typing import List, Union
 import pytorch_bigtable.version_filters as filters
 
 
@@ -87,7 +87,7 @@ class BigtableTable:
                                                   self._app_profile_id)
 
   def write_tensor(self, tensor: torch.Tensor, columns: List[str],
-                   row_keys: List[str], ):
+                   row_keys: List[str]):
     """Opens a connection and writes data from tensor.
 
     Args:
@@ -115,8 +115,9 @@ class BigtableTable:
 
   def read_rows(self, cell_type: torch.dtype, columns: List[str],
                 row_set: pbt_C.RowSet,
-                versions: pbt_C.Filter = filters.latest()) -> \
-      torch.utils.data.IterableDataset:
+                versions: pbt_C.Filter = filters.latest(),
+                fill_value: Union[int, float] = 0) -> \
+                torch.utils.data.IterableDataset:
     """Returns a `CloudBigtableIterableDataset` object.
 
     Args:
@@ -127,9 +128,11 @@ class BigtableTable:
         row_set (RowSet): set of rows to read.
         versions (Filter):
             specifies which version should be retrieved. Defaults to latest.
+        fill_value (float|int): value to fill missing values with.
     """
 
-    return _BigtableDataset(self, columns, cell_type, row_set, versions)
+    return _BigtableDataset(self, columns, cell_type, row_set, versions,
+                            fill_value)
 
 
 class _BigtableDataset(torch.utils.data.IterableDataset):
@@ -137,7 +140,8 @@ class _BigtableDataset(torch.utils.data.IterableDataset):
 
   def __init__(self, table: BigtableTable, columns: List[str],
                cell_type: torch.dtype, row_set: pbt_C.RowSet,
-               versions: pbt_C.Filter = filters.latest()) -> None:
+               versions: pbt_C.Filter = filters.latest(),
+               fill_value: Union[int, float] = 0) -> None:
     super(_BigtableDataset).__init__()
 
     self._table = table
@@ -145,6 +149,7 @@ class _BigtableDataset(torch.utils.data.IterableDataset):
     self._cell_type = cell_type
     self._row_set = row_set
     self._versions = versions
+    self._fill_value = fill_value
 
   def __iter__(self):
     """
@@ -166,4 +171,4 @@ class _BigtableDataset(torch.utils.data.IterableDataset):
                           self._table._app_profile_id,
                           self._table._sample_row_keys, self._columns,
                           self._cell_type, self._row_set, self._versions,
-                          num_workers, worker_id)
+                          self._fill_value, num_workers, worker_id)

--- a/plugin/pytorch_bigtable/bigtable_dataset.py
+++ b/plugin/pytorch_bigtable/bigtable_dataset.py
@@ -116,7 +116,7 @@ class BigtableTable:
   def read_rows(self, cell_type: torch.dtype, columns: List[str],
                 row_set: pbt_C.RowSet,
                 versions: pbt_C.Filter = filters.latest(),
-                fill_value: Union[int, float] = 0) -> \
+                default_value: Union[int, float] = None) -> \
                 torch.utils.data.IterableDataset:
     """Returns a `CloudBigtableIterableDataset` object.
 
@@ -128,11 +128,11 @@ class BigtableTable:
         row_set (RowSet): set of rows to read.
         versions (Filter):
             specifies which version should be retrieved. Defaults to latest.
-        fill_value (float|int): value to fill missing values with.
+        default_value (float|int): value to fill missing values with.
     """
 
     return _BigtableDataset(self, columns, cell_type, row_set, versions,
-                            fill_value)
+                            default_value)
 
 
 class _BigtableDataset(torch.utils.data.IterableDataset):
@@ -141,7 +141,7 @@ class _BigtableDataset(torch.utils.data.IterableDataset):
   def __init__(self, table: BigtableTable, columns: List[str],
                cell_type: torch.dtype, row_set: pbt_C.RowSet,
                versions: pbt_C.Filter = filters.latest(),
-               fill_value: Union[int, float] = 0) -> None:
+               default_value: Union[int, float] = None) -> None:
     super(_BigtableDataset).__init__()
 
     self._table = table
@@ -149,7 +149,7 @@ class _BigtableDataset(torch.utils.data.IterableDataset):
     self._cell_type = cell_type
     self._row_set = row_set
     self._versions = versions
-    self._fill_value = fill_value
+    self._default_value = default_value
 
   def __iter__(self):
     """
@@ -171,4 +171,4 @@ class _BigtableDataset(torch.utils.data.IterableDataset):
                           self._table._app_profile_id,
                           self._table._sample_row_keys, self._columns,
                           self._cell_type, self._row_set, self._versions,
-                          self._fill_value, num_workers, worker_id)
+                          self._default_value, num_workers, worker_id)

--- a/plugin/pytorch_bigtable/tests/test_read_rows.py
+++ b/plugin/pytorch_bigtable/tests/test_read_rows.py
@@ -61,7 +61,7 @@ class BigtableReadTest(unittest.TestCase):
                                     row_range.infinite())):
       results.append(tensor.reshape(1, -1))
     result = torch.cat(results)
-    self.assertTrue(result[:, 1].isnan().all().item())
+    self.assertTrue((result[:, 1] == 0.).all().item())
     self.assertTrue((result[:, 0] == ten[:, 0]).all().item())
 
   def test_read_int64(self):

--- a/plugin/pytorch_bigtable/tests/test_read_rows.py
+++ b/plugin/pytorch_bigtable/tests/test_read_rows.py
@@ -59,8 +59,7 @@ class BigtableReadTest(unittest.TestCase):
     results = []
     for tensor in table.read_rows(torch.float32, ["fam1:col1", "fam1:col2"],
                                   row_set.from_rows_or_ranges(
-                                    row_range.infinite()),
-                                  fill_value=float("NaN")):
+                                    row_range.infinite())):
       results.append(tensor.reshape(1, -1))
       print(f"Got tensor: {tensor}")
     result = torch.cat(results)
@@ -84,7 +83,7 @@ class BigtableReadTest(unittest.TestCase):
     results = []
     for tensor in table.read_rows(torch.int64, ["fam1:col1", "fam1:col2"],
                                   row_set.from_rows_or_ranges(
-                                    row_range.infinite()), fill_value=0):
+                                    row_range.infinite()), default_value=0):
       results.append(tensor.reshape(1, -1))
       print(f"Got tensor: {tensor}")
     result = torch.cat(results)

--- a/plugin/pytorch_bigtable/tests/test_read_rows.py
+++ b/plugin/pytorch_bigtable/tests/test_read_rows.py
@@ -22,6 +22,10 @@ class BigtableReadTest(unittest.TestCase):
                                ["fam1", "fam2"])
 
     ten = torch.Tensor(list(range(40))).reshape(20, 2)
+    ten[1, 0] = float("NaN")
+    ten[5, 0] = float("NaN")
+    ten[3, 1] = float("NaN")
+    ten[8, 1] = float("NaN")
 
     client = BigtableClient("fake_project", "fake_instance",
                             endpoint=self.emulator.get_addr())
@@ -29,6 +33,61 @@ class BigtableReadTest(unittest.TestCase):
 
     table.write_tensor(ten, ["fam1:col1", "fam2:col2"],
                        ["row" + str(i).rjust(3, "0") for i in range(20)])
-    for tensor in table.read_rows(torch.float32, ["fam1:col1", "fam1:col2"],
-        row_set.from_rows_or_ranges(row_range.infinite())):
+    results = []
+    for tensor in table.read_rows(torch.float32, ["fam1:col1", "fam2:col2"],
+                                  row_set.from_rows_or_ranges(
+                                    row_range.infinite())):
+      results.append(tensor.reshape(1, -1))
       print(f"Got tensor: {tensor}")
+    result = torch.cat(results)
+    self.assertTrue((result.isnan() == ten.isnan()).all().item())
+    self.assertTrue((result.nan_to_num(0) == ten.nan_to_num(0)).all().item())
+
+  def test_read_nan(self):
+    os.environ["BIGTABLE_EMULATOR_HOST"] = self.emulator.get_addr()
+    self.emulator.create_table("fake_project", "fake_instance", "test-table",
+                               ["fam1", "fam2"])
+
+    ten = torch.Tensor(list(range(40))).reshape(20, 2)
+
+    client = BigtableClient("fake_project", "fake_instance",
+                            endpoint=self.emulator.get_addr())
+    table = client.get_table("test-table")
+
+    table.write_tensor(ten, ["fam1:col1", "fam2:col2"],
+                       ["row" + str(i).rjust(3, "0") for i in range(20)])
+    results = []
+    for tensor in table.read_rows(torch.float32, ["fam1:col1", "fam1:col2"],
+                                  row_set.from_rows_or_ranges(
+                                    row_range.infinite()),
+                                  fill_value=float("NaN")):
+      results.append(tensor.reshape(1, -1))
+      print(f"Got tensor: {tensor}")
+    result = torch.cat(results)
+    self.assertTrue(result[:, 1].isnan().all().item())
+    self.assertTrue((result[:, 0] == ten[:, 0]).all().item())
+
+  def test_read_int64(self):
+    os.environ["BIGTABLE_EMULATOR_HOST"] = self.emulator.get_addr()
+    self.emulator.create_table("fake_project", "fake_instance", "test-table",
+                               ["fam1", "fam2"])
+
+    ten = torch.Tensor(list(range(40))).reshape(20, 2).long()
+
+    client = BigtableClient("fake_project", "fake_instance",
+                            endpoint=self.emulator.get_addr())
+    table = client.get_table("test-table")
+
+    table.write_tensor(ten, ["fam1:col1", "fam2:col2"],
+                       ["row" + str(i).rjust(3, "0") for i in range(20)])
+
+    results = []
+    for tensor in table.read_rows(torch.int64, ["fam1:col1", "fam1:col2"],
+                                  row_set.from_rows_or_ranges(
+                                    row_range.infinite()), fill_value=0):
+      results.append(tensor.reshape(1, -1))
+      print(f"Got tensor: {tensor}")
+    result = torch.cat(results)
+    ten[:, 1] = 0
+    different_elements = (ten != result).sum().item()
+    self.assertEqual(different_elements, 0)

--- a/plugin/pytorch_bigtable/tests/test_read_rows.py
+++ b/plugin/pytorch_bigtable/tests/test_read_rows.py
@@ -38,7 +38,6 @@ class BigtableReadTest(unittest.TestCase):
                                   row_set.from_rows_or_ranges(
                                     row_range.infinite())):
       results.append(tensor.reshape(1, -1))
-      print(f"Got tensor: {tensor}")
     result = torch.cat(results)
     self.assertTrue((result.isnan() == ten.isnan()).all().item())
     self.assertTrue((result.nan_to_num(0) == ten.nan_to_num(0)).all().item())
@@ -61,7 +60,6 @@ class BigtableReadTest(unittest.TestCase):
                                   row_set.from_rows_or_ranges(
                                     row_range.infinite())):
       results.append(tensor.reshape(1, -1))
-      print(f"Got tensor: {tensor}")
     result = torch.cat(results)
     self.assertTrue(result[:, 1].isnan().all().item())
     self.assertTrue((result[:, 0] == ten[:, 0]).all().item())
@@ -85,7 +83,6 @@ class BigtableReadTest(unittest.TestCase):
                                   row_set.from_rows_or_ranges(
                                     row_range.infinite()), default_value=0):
       results.append(tensor.reshape(1, -1))
-      print(f"Got tensor: {tensor}")
     result = torch.cat(results)
     ten[:, 1] = 0
     different_elements = (ten != result).sum().item()


### PR DESCRIPTION
This PR adds support for more datatypes. If this approach is accepted, then support for all datatypes possible in pytorch will be added in the next PR.

Also, we expect the user to provide the default value for missing values. Originally we wanted it to just be NaN, then the user can use nan_to_num and replace it to whatever they wish. However, this would not work for tensors with integers, since integers cannot be NaN. instead we ask the user to provide a value, (if the tensor type is float, it can be NaN) and if they don't, the default is 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/pytorch-cbt/26)
<!-- Reviewable:end -->
