### PR TITLE
feat: write callback

### DIFF
--- a/plugin/csrc/bigtable_dataset.cc
+++ b/plugin/csrc/bigtable_dataset.cc
@@ -181,11 +181,10 @@ py::list SampleRowKeys(py::object const& client, std::string const& table_id,
 std::string getRowKey(
     torch::Tensor const& tensor, int i,
     std::optional<py::list> const& row_key_list,
-    std::optional<std::function<std::string(torch::Tensor const&)>> const&
+    std::optional<std::function<std::string(torch::Tensor const&, int)>> const&
         row_key_callable) {
   if (row_key_list) return (*row_key_list)[i].cast<std::string>();
-  std::cout << "getting slice " << i << ":" << (i + 1) << "\n";
-  return (*row_key_callable)(tensor.slice(0, i, i + 1));
+  return (*row_key_callable)(tensor.slice(0, i, i + 1), i);
 }
 
 void WriteTensor(
@@ -193,7 +192,7 @@ void WriteTensor(
     std::optional<std::string> const& app_profile_id,
     torch::Tensor const& tensor, py::list const& columns,
     std::optional<py::list> const& row_key_list,
-    std::optional<std::function<std::string(torch::Tensor const&)>> const&
+    std::optional<std::function<std::string(torch::Tensor const&, int)>> const&
         row_key_callable) {
   std::shared_ptr<cbt::DataClient> data_client = CreateDataClient(client);
   auto table = CreateTable(data_client, table_id, app_profile_id);

--- a/plugin/pytorch_bigtable/bigtable_dataset.py
+++ b/plugin/pytorch_bigtable/bigtable_dataset.py
@@ -98,8 +98,11 @@ class BigtableTable:
             [ "column_family_a:column_name_a",
             "column_family_a:column_name_b",
             ...]
-        row_keys: list of row_keys that should be used for the rows in the
-        tensor.
+        row_keys: a list or a callback.
+        If a list, it is a set of row_keys
+        that should be used for the rows in the tensor.
+        If a callback, it is called with the `tensor`'s row and is
+        expected to return a row_key for that row.
 
     """
     if tensor.dim() != 2:
@@ -128,9 +131,8 @@ class BigtableTable:
 
   def read_rows(self, cell_type: torch.dtype, columns: List[str],
                 row_set: pbt_C.RowSet,
-                versions: pbt_C.Filter = filters.latest(),
-                default_value: Union[int, float] = None) -> \
-                torch.utils.data.IterableDataset:
+                versions: pbt_C.Filter = filters.latest(), default_value: Union[
+        int, float] = None) -> torch.utils.data.IterableDataset:
     """Returns a `CloudBigtableIterableDataset` object.
 
     Args:

--- a/plugin/pytorch_bigtable/bigtable_dataset.py
+++ b/plugin/pytorch_bigtable/bigtable_dataset.py
@@ -90,20 +90,25 @@ class BigtableTable:
   def write_tensor(self, tensor: torch.Tensor, columns: List[str],
                    row_keys: Union[
                      List[str], Callable[[torch.Tensor, int], str]]):
-    """Opens a connection and writes data from tensor.
+    """Opens a connection and writes data from tensor. Each row of this
+    tensor will become a row in Bigtable so you should provide as many
+    row-keys as tensor.shape(1). Please note that using this function is
+    strongly discouraged for large amounts of data. Because it creates a new
+    connection every time it is called, it has a non-trivial constant cost,
+    so calling it thousands times is not the greatest idea.
 
     Args:
-        tensor: Two dimentional PyTorch Tensor.
+        tensor: Two dimensional PyTorch Tensor.
         columns: List with names of the columns in the table that
             should be read, i.e:
             [ "column_family_a:column_name_a",
             "column_family_a:column_name_b",
             ...]
         row_keys: a list or a callback.
-        If a list, it is a set of row_keys
-        that should be used for the rows in the tensor.
-        If a callback, it is called with the `tensor`'s row and index and is
-        expected to return a row_key for that row.
+          If a list, it is a set of row_keys
+          that should be used for the rows in the tensor.
+          If a callback, it is called with the `tensor`'s row and index and is
+          expected to return a row_key for that row.
 
     """
     if tensor.dim() != 2:

--- a/plugin/pytorch_bigtable/bigtable_dataset.py
+++ b/plugin/pytorch_bigtable/bigtable_dataset.py
@@ -88,7 +88,8 @@ class BigtableTable:
                                                   self._app_profile_id)
 
   def write_tensor(self, tensor: torch.Tensor, columns: List[str],
-                   row_keys: Union[List[str], Callable[[torch.Tensor, int], str]]):
+                   row_keys: Union[
+                     List[str], Callable[[torch.Tensor, int], str]]):
     """Opens a connection and writes data from tensor.
 
     Args:

--- a/plugin/pytorch_bigtable/bigtable_dataset.py
+++ b/plugin/pytorch_bigtable/bigtable_dataset.py
@@ -88,7 +88,7 @@ class BigtableTable:
                                                   self._app_profile_id)
 
   def write_tensor(self, tensor: torch.Tensor, columns: List[str],
-                   row_keys: Union[List[str], Callable[[torch.Tensor], str]]):
+                   row_keys: Union[List[str], Callable[[torch.Tensor, int], str]]):
     """Opens a connection and writes data from tensor.
 
     Args:
@@ -101,7 +101,7 @@ class BigtableTable:
         row_keys: a list or a callback.
         If a list, it is a set of row_keys
         that should be used for the rows in the tensor.
-        If a callback, it is called with the `tensor`'s row and is
+        If a callback, it is called with the `tensor`'s row and index and is
         expected to return a row_key for that row.
 
     """

--- a/plugin/pytorch_bigtable/tests/test_write_tensor.py
+++ b/plugin/pytorch_bigtable/tests/test_write_tensor.py
@@ -122,14 +122,16 @@ class BigtableWriteTest(unittest.TestCase):
                             endpoint=self.emulator.get_addr())
     table = client.get_table("test-table")
 
+    row_keys_list = ["row" + str(random.randint(1000, 9999)).rjust(4, "0") for _
+                     in range(20)]
+
     def row_callback(tensor, index):
-      return "row" + str(random.randint(1000, 9999)).rjust(4, "0")
+      return row_keys_list[index]
 
     table.write_tensor(ten, ["fam1:col1", "fam2:col2"], row_callback)
     results = []
     for tensor in table.read_rows(torch.float32, ["fam1:col1", "fam2:col2"],
-                                  row_set.from_rows_or_ranges(
-                                    row_range.infinite())):
+                                  row_set.from_rows_or_ranges(*row_keys_list)):
       results.append(tensor.reshape(1, -1))
     results = sorted(results, key=lambda x: x[0, 0].item())
     result = torch.cat(results)

--- a/plugin/pytorch_bigtable/tests/test_write_tensor.py
+++ b/plugin/pytorch_bigtable/tests/test_write_tensor.py
@@ -16,6 +16,8 @@
 # pylint: disable=C0114
 # disable class docstring for tests
 # pylint: disable=C0115
+# disable unused parameter for callback
+# pylint: disable=W0613
 import random
 import unittest
 import torch

--- a/plugin/pytorch_bigtable/tests/test_write_tensor.py
+++ b/plugin/pytorch_bigtable/tests/test_write_tensor.py
@@ -120,7 +120,7 @@ class BigtableWriteTest(unittest.TestCase):
                             endpoint=self.emulator.get_addr())
     table = client.get_table("test-table")
 
-    def row_callback(tensor):
+    def row_callback(tensor, index):
       return "row" + str(random.randint(1000, 9999)).rjust(4, "0")
 
     table.write_tensor(ten, ["fam1:col1", "fam2:col2"], row_callback)


### PR DESCRIPTION
To avoid an anti-pattern of adding consecutive row_keys, a callback is added. The user can now specify a function that will be called with an index and a row of the tensor being written. This function is expected to return a row_key of type string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/pytorch-cbt/31)
<!-- Reviewable:end -->
