### PR TITLE
fix: configuration in setup.py

### DIFF
--- a/plugin/setup.py
+++ b/plugin/setup.py
@@ -90,6 +90,7 @@ setup(name="pytorch_bigtable", version=version, author="Google",
       author_email="info@unoperate.com",
       description="Pytorch Extension for BigTable",
       long_description=long_description,
+      long_description_content_type='text/markdown',
       classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
A while ago we changed the long description to be a readme, but we didn't change the type to markdown and not pypi complains when uploading a new wheel.